### PR TITLE
#59 set_logger_level with examples and move to Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # stage: baseline
-FROM python:3.10-slim-buster AS base
+FROM python:3.10-slim-bullseye AS base
 
 ENV PIP_DEFAULT_TIMEOUT=100 \
   PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 """Main entry point."""
 
-from py_scaffolding.example import demo, demo_with_logger
+from py_scaffolding.example import example
 
 if __name__ == "__main__":
-    demo_with_logger()
-    print(demo())
+    example()

--- a/py_scaffolding/example.py
+++ b/py_scaffolding/example.py
@@ -1,10 +1,11 @@
 """An example to show everything is working."""
-from py_scaffolding.logging import set_up_logger
+from py_scaffolding.logging import set_logger_level, set_up_logger
+from py_scaffolding.settings import Settings
 
 LOG = set_up_logger(logger_name=__name__)
 
 
-def demo() -> int:
+def demo() -> int:  # pragma: no cover
     """
     A very simple function to show docstrings with doctests are executed by pytest.
 
@@ -16,7 +17,7 @@ def demo() -> int:
     return 42
 
 
-def demo_with_logger() -> None:
+def demo_with_logger() -> None:  # pragma: no cover
     """
     To test and demonstrate the use of logger.
     """
@@ -25,3 +26,12 @@ def demo_with_logger() -> None:
         some_key="some value",
         another_key=True,
     )
+
+
+def example() -> None:  # pragma: no cover
+    """A very basic example using the helpers provided by this scaffolding project."""
+    settings = Settings()
+    set_logger_level(logger=LOG, level=settings.LOG_LEVEL)
+
+    demo_with_logger()
+    print(demo())

--- a/py_scaffolding/logging.py
+++ b/py_scaffolding/logging.py
@@ -11,14 +11,14 @@ import structlog
 
 def set_up_logger(
     *, logger_name: str, log_level: int = logging.INFO
-) -> structlog.stdlib.BoundLogger:
+) -> structlog.stdlib.BoundLogger:  # pragma: no cover
     """
-    Setup the logger object to use in your code.
+    Set up the logger object to use in your code.
 
     ..  code-block:: python
         :caption: Minimal example
 
-        from applications_processing.helpers.logging import set_up_logger
+        from py_scaffolding.logging import set_up_logger
         LOG = set_up_logger(logger_name=__name__)
 
         # ... later in the code ...
@@ -32,18 +32,41 @@ def set_up_logger(
     _set_up_structlog()
     logger = structlog.get_logger(logger_name)
     logger.setLevel(log_level)
-    if not logger.new()._logger.handlers:  # pragma: no cover
+    if not logger.new()._logger.handlers:
         logger.addHandler(_configure_logger_handlers())
     return logger
 
 
-def _configure_logger_handlers() -> logging.StreamHandler:
+def set_logger_level(
+    *, logger: structlog.stdlib.BoundLogger, level: str
+):  # pragma: no cover
+    """
+    Allow to set a new logging level by name for an existing logger.
+
+    ..  code-block:: python
+        :caption: Minimal example
+
+        from py_scaffolding.logging import set_logger_level
+
+        # ... in the entry point ...
+        set_logger_level(logger=LOG, level="DEBUG")
+    """
+    # NOTE: level is not further refined with a Literal of allowed strings due to the dynamic nature of logging levels.
+    clean_level = level.upper()
+    numeric_level = getattr(logging, clean_level)
+    logger.setLevel(numeric_level)
+    logger.info(
+        "Log level changed", new_level=clean_level, new_level_numeric=numeric_level
+    )
+
+
+def _configure_logger_handlers() -> logging.StreamHandler:  # pragma: no cover
     """Internal helper to add handlers."""
     logger_handler = logging.StreamHandler(sys.stdout)
     return logger_handler
 
 
-def _set_up_structlog() -> None:
+def _set_up_structlog() -> None:  # pragma: no cover
     """
     Internal helper to configure structlog.
 

--- a/py_scaffolding/settings.py
+++ b/py_scaffolding/settings.py
@@ -1,0 +1,11 @@
+"""Settings from environment."""
+
+from typing import Literal
+
+from pydantic import BaseSettings  # pylint: disable=no-name-in-module
+
+
+class Settings(BaseSettings):  # pragma: no cover
+    """Set those variables in the environment."""
+
+    LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ disable = ''',
     too-many-arguments,
     too-many-instance-attributes,
     too-many-ancestors,
+    too-few-public-methods,
     '''
 
 [tool.pylint.options]


### PR DESCRIPTION
This PR fixes #59 

I confirm that before submitting this PR I have:

- [X] run `make` in my local environment with no errors.

## Release Notes

- Debian Bullseye slim
- added `set_logger_level` with examples